### PR TITLE
Add username to profile

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -102,6 +102,8 @@ Strategy.prototype.userProfile = function(AccessToken, done) {
       profile[a.Name] = a.Value;
     }
     
+    profile.username = userData.Username;
+
     done(null, profile);
   });
   


### PR DESCRIPTION
Username was not present in `profile` because it's not a part of `UserAttributes`.