### PR TITLE
Extend Strategy to optionally target Identity Provider

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -35,6 +35,8 @@ const util = require('util')
  *   - `clientSecret`      AWS Cognito user pool app client secret
  *   - `passReqToCallback` when `true`, `req` is the first argument to the verify callback (default: `false`)
  *   - `region`            AWS Cognito user pool region
+ *   - 'scope'             AWS scope to use
+ *   - 'identity_provider'  Target a specific identity provider 'Google','Facebook','Cognito'
  *
  * Examples:
  *
@@ -58,14 +60,16 @@ const util = require('util')
  * @api public
  */
 
-function Strategy({clientDomain, clientID, clientSecret, callbackURL, passReqToCallback, region}, verify) {
+function Strategy({clientDomain, clientID, clientSecret, callbackURL, passReqToCallback, region, scope, identity_provider}, verify) {
   const options = {
     authorizationURL: `${clientDomain}/oauth2/authorize`,
     clientID,
     clientSecret,
     callbackURL,
     passReqToCallback,
-    tokenURL: `${clientDomain}/oauth2/token`
+    tokenURL: `${clientDomain}/oauth2/token`,
+    scope,
+    identity_provider
   };
 
   OAuth2Strategy.call(this, options, verify);
@@ -80,6 +84,32 @@ function Strategy({clientDomain, clientID, clientSecret, callbackURL, passReqToC
  * Inherit from `OAuth2Strategy`.
  */
 util.inherits(Strategy, OAuth2Strategy);
+
+/**
+ * Extend the OAuth2Strategy to accept identity_provider param to target (Google, Facebook, Cognito)
+ *
+ * Examples:
+ *
+ * router.post('/login/google',
+ *    passport.authenticate('oauth2-cognito', {
+ *     identity_provider:  'Google',
+ *     scope:          'openid profile email aws.cognito.signin.user.admin',
+ *     responseType:   'code',
+ *     failureRedirect: '/login',
+ *     redirectUri:    process.env.COGNITO_AUTH_CALLBACK || 'http://localhost:10010/auth/callback'
+ *   }));
+ *
+ * @param {Object} options
+ * @api private
+ */
+Strategy.prototype.authorizationParams = function(options) {
+    let params = {};
+    if (options.identity_provider && typeof options.identity_provider === 'string') {
+        params.identity_provider = options.identity_provider;
+    }
+
+    return params;
+};
 
 /**
  * Retrieve user profile from AWS Cognito.
@@ -105,7 +135,7 @@ Strategy.prototype.userProfile = function(AccessToken, done) {
     done(null, profile);
   });
   
-}
+};
 
 
 /**


### PR DESCRIPTION
Extended Strategy authorizationParams from OAuth2Strategy to allow user
to target a specific identity_provider from cognito (Google, Facebook,
Cognito, Amazon). This is convenient if you don't want to see the Cognito hosted login page and directly target the identity provider